### PR TITLE
add comment character to lisp language settings

### DIFF
--- a/settings/language-lisp.cson
+++ b/settings/language-lisp.cson
@@ -1,3 +1,4 @@
 '.source.lisp':
   'editor':
+    'commentStart': '; '
     'increaseIndentPattern': '^.*\\(.*[^)"]$'


### PR DESCRIPTION
This lets atom use the `cmd + /` shortcut to create comments.
