### PR TITLE
Add 'lsp' extension as a Lisp file

### DIFF
--- a/grammars/lisp.cson
+++ b/grammars/lisp.cson
@@ -1,6 +1,7 @@
 'comment': ''
 'fileTypes': [
   'lisp'
+  'lsp'
   'cl'
   'l'
   'mud'


### PR DESCRIPTION
Google Koans use the .lsp extension and should be supported.
