### PR TITLE
Add support for toggling comments.

### DIFF
--- a/settings/language-lisp.cson
+++ b/settings/language-lisp.cson
@@ -1,3 +1,4 @@
 '.source.lisp':
   'editor':
+    'commentStart': '; '
     'increaseIndentPattern': '^.*\\(.*[^)"]$'


### PR DESCRIPTION
In Atom one can automatically comment a single line or a block of code by the hotkey `Cmd + /` (Mac, equivalents on other platforms). The Lisp syntax did not specify the comment character, which made Atom insert a non-Lisp `/* */` comment block. This change corrects that to `;`.
