### PR TITLE
Grammars & snippets overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# language-lisp package
+# Lisp language support in Atom
 
 Originally converted from [Texmate lisp bundle](https://github.com/textmate/lisp.tmbundle) as explained in the [atom guide](http://atom.io/docs/latest/converting-a-text-mate-bundle). However some work to properly customize this package for Atom is still needed.
+
+Lisp is a big family of programming languages. This particular package is intended for the most popular Lisp dialect -- the Common Lisp.
 
 For proper lisp indentation and better lisp-editing experience this package should be used in conjunction with some advanced lisp editing tool:
 - Parinfer (suitable for beginners and gurus alike)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Originally converted from [Texmate lisp bundle](https://github.com/textmate/lisp.tmbundle) as explained in the [atom guide](http://atom.io/docs/latest/converting-a-text-mate-bundle). However some work to properly customize this package for Atom is still needed.
 
-Lisp is a big family of programming languages. This particular package is intended for the most popular Lisp dialect -- the Common Lisp.
+Lisp is a big family of programming languages. This package is primarily intended for the most popular Lisp dialect — the Common Lisp.
 
 For proper lisp indentation and better lisp-editing experience this package should be used in conjunction with some advanced lisp editing tool:
 - Parinfer (suitable for beginners and gurus alike)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Lisp language support in Atom
 
-Originally converted from [Texmate lisp bundle](https://github.com/textmate/lisp.tmbundle) as explained in the [atom guide](http://atom.io/docs/latest/converting-a-text-mate-bundle). However some work to properly customize this package for Atom is still needed.
+Originally converted from [Texmate lisp bundle](https://github.com/textmate/lisp.tmbundle) as explained in the [atom guide](http://atom.io/docs/latest/converting-a-text-mate-bundle).
+Some effort to properly customize this package for Atom might still be needed.
 
-Lisp is a big family of programming languages. This package is primarily intended for the most popular Lisp dialect — the Common Lisp.
+Lisp is a big family of programming languages. This package is primarily intended for the most popular Lisp dialect – the Common Lisp.
 
-For proper lisp indentation and better lisp-editing experience this package should be used in conjunction with some advanced lisp editing tool:
-- Parinfer (suitable for beginners and gurus alike)
-- [Paredit](https://atom.io/packages/lisp-paredit) (recommended for advanced users)
+For proper Lisp indentation and better editing experience this package should be used in conjunction with some advanced editing tool:
+- [Parinfer](https://atom.io/packages/parinfer) (suitable for beginners and gurus alike; automatically manages parenthesses based on indentation)
+- [Paredit](https://atom.io/packages/lisp-paredit) (recommended for advanced users; manipulates code as abstract syntax tree)

--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ Some effort to properly customize this package for Atom might still be needed.
 Lisp is a big family of programming languages. This package is primarily intended for the most popular Lisp dialect – the Common Lisp.
 
 For proper Lisp indentation and better editing experience this package should be used in conjunction with some advanced editing tool:
-- [Parinfer](https://atom.io/packages/parinfer) (suitable for beginners and gurus alike; automatically manages parenthesses based on indentation)
+- [Parinfer](https://atom.io/packages/parinfer) (suitable for beginners and gurus alike; automatically manages parentheses based on indentation)
 - [Paredit](https://atom.io/packages/lisp-paredit) (recommended for advanced users; manipulates code as abstract syntax tree)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # language-lisp package
 
-Converted from [Texmate lisp bundle](https://github.com/textmate/lisp.tmbundle) as explained in the [atom guide](http://atom.io/docs/latest/converting-a-text-mate-bundle).
+Originally converted from [Texmate lisp bundle](https://github.com/textmate/lisp.tmbundle) as explained in the [atom guide](http://atom.io/docs/latest/converting-a-text-mate-bundle). However some work to properly customize this package for Atom is still needed.
+
+For proper lisp indentation and better lisp-editing experience this package should be used in conjunction with some advanced lisp editing tool:
+- Parinfer (suitable for beginners and gurus alike)
+- [Paredit](https://atom.io/packages/lisp-paredit) (recommended for advanced users)

--- a/grammars/lisp.cson
+++ b/grammars/lisp.cson
@@ -1,3 +1,4 @@
+name: 'Lisp'
 scopeName: 'source.lisp'
 fileTypes: [
   'lisp'
@@ -6,7 +7,6 @@ fileTypes: [
   'mud'
   'el'
 ]
-name: 'Lisp'
 foldingStartMarker: '\\(\\s*$'
 foldingStopMarker: '^\\s*\\)'
 patterns: [

--- a/grammars/lisp.cson
+++ b/grammars/lisp.cson
@@ -12,75 +12,83 @@ foldingStartMarker: '\\(\\s*$'
 foldingStopMarker: '^\\s*\\)'
 patterns: [
   {
-    begin: '(^[ \\t]+)?(?=;)'
-    beginCaptures:
-      '1':
-        name: 'punctuation.whitespace.comment.leading.lisp'
-    end: '(?!\\G)'
-    patterns: [
-      {
-        begin: ';'
-        beginCaptures:
-          '0':
-            name: 'punctuation.definition.comment.lisp'
-        end: '\\n'
-        name: 'comment.line.semicolon.lisp'
-      }
-    ]
+    match: '(;).*$\\n?'
+    captures:
+      1:
+        name: 'punctuation.definition.comment.lisp'
+    name: 'comment.line.semicolon.lisp'
   }
   {
+    match: '(\\b(?i:(defun|labels|defmacro|defstruct|defclass|defmethod|defconstant|defparameter|defvar))\\b)(\\s+)((\\w|\\-|\\!|\\?)*)'
     captures:
-      '2':
+      2:
         name: 'storage.type.function-type.lisp'
-      '4':
+      4:
         name: 'entity.name.function.lisp'
-    match: '(\\b(?i:(defun|defmethod|defmacro))\\b)(\\s+)((\\w|\\-|\\!|\\?)*)'
     name: 'meta.function.lisp'
   }
   {
-    captures:
-      '1':
-        name: 'punctuation.definition.constant.lisp'
     match: '(#)(\\w|[\\\\+-=<>\'"&#])+'
+    captures:
+      1:
+        name: 'punctuation.definition.constant.lisp'
     name: 'constant.character.lisp'
   }
   {
+    match: '(?:^|\\s|\\()(:|&)([a-zA-Z0-9\\#\\.\\-\\_\\+\\=\\>\\<\\/\\!\\?\\*\\[\\]\\{\\}]+)'
     captures:
-      '1':
-        name: 'punctuation.definition.variable.lisp'
-      '3':
-        name: 'punctuation.definition.variable.lisp'
+      1:
+        name: 'punctuation.definition.constant.lisp'
+      2:
+        name: 'punctuation.definition.constant.lisp'
+    name: 'meta.definition.lisp'
+  }
+  {
     match: '(\\*)(\\S*)(\\*)'
+    captures:
+      1:
+        name: 'punctuation.definition.variable.lisp'
+      3:
+        name: 'punctuation.definition.variable.lisp'
     name: 'variable.other.global.lisp'
   }
   {
-    match: '\\b(?i:case|do|let|loop|if|else|when)\\b'
+    match: '(\\+)(\\S*)(\\+)'
+    captures:
+      1:
+        name: 'punctuation.definition.constant.lisp'
+      3:
+        name: 'punctuation.definition.constant.lisp'
+    name: 'constant.other.global.lisp'
+  }
+  {
+    match: '\\b(?i:let|let\\*|case|do|dolist|dotimes|loop|if|cond|when|unless)\\b'
     name: 'keyword.control.lisp'
   }
   {
-    match: '\\b(?i:eq|neq|and|or)\\b'
+    match: '\\b(?i:eq|eql|equal|neq|and|or|not)\\b'
     name: 'keyword.operator.lisp'
   }
   {
-    match: '\\b(?i:null|nil)\\b'
-    name: 'constant.language.lisp'
+    match: '\\b(?i:t|nil)\\b'
+    name: 'constant.language.boolean.nil.lisp'
   }
   {
-    match: '\\b(?i:cons|car|cdr|cond|lambda|format|setq|setf|quote|eval|append|list|listp|memberp|t|load|progn)\\b'
+    match: '\\b(?i:cons|car|cdr|lambda|format|print|setq|setf|quote|eval|append|list|listp|memberp|load|progn|apply|mapcar)\\b'
     name: 'support.function.lisp'
   }
   {
-    match: '\\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\\b'
+    match: '\\b((([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)\\b'
     name: 'constant.numeric.lisp'
   }
   {
     begin: '"'
     beginCaptures:
-      '0':
+      0:
         name: 'punctuation.definition.string.begin.lisp'
     end: '"'
     endCaptures:
-      '0':
+      0:
         name: 'punctuation.definition.string.end.lisp'
     name: 'string.quoted.double.lisp'
     patterns: [
@@ -89,5 +97,16 @@ patterns: [
         name: 'constant.character.escape.lisp'
       }
     ]
+  }
+  {
+    begin: '#\\|'
+    beginCaptures:
+      0:
+        name: 'punctuation.definition.comment.begin.lisp'
+    end: '\\|#'
+    endCaptures:
+      0:
+        name: 'punctuation.definition.comment.end.lisp'
+    name: 'comment.block.hash.lisp'
   }
 ]

--- a/grammars/lisp.cson
+++ b/grammars/lisp.cson
@@ -1,91 +1,92 @@
-'comment': ''
-'fileTypes': [
+scopeName: 'source.lisp'
+fileTypes: [
   'lisp'
   'cl'
   'l'
   'mud'
   'el'
 ]
-'name': 'Lisp'
-'patterns': [
+name: 'Lisp'
+foldingStartMarker: '\\(\\s*$'
+foldingStopMarker: '^\\s*\\)'
+patterns: [
   {
-    'begin': '(^[ \\t]+)?(?=;)'
-    'beginCaptures':
+    begin: '(^[ \\t]+)?(?=;)'
+    beginCaptures:
       '1':
-        'name': 'punctuation.whitespace.comment.leading.lisp'
-    'end': '(?!\\G)'
-    'patterns': [
+        name: 'punctuation.whitespace.comment.leading.lisp'
+    end: '(?!\\G)'
+    patterns: [
       {
-        'begin': ';'
-        'beginCaptures':
+        begin: ';'
+        beginCaptures:
           '0':
-            'name': 'punctuation.definition.comment.lisp'
-        'end': '\\n'
-        'name': 'comment.line.semicolon.lisp'
+            name: 'punctuation.definition.comment.lisp'
+        end: '\\n'
+        name: 'comment.line.semicolon.lisp'
       }
     ]
   }
   {
-    'captures':
+    captures:
       '2':
-        'name': 'storage.type.function-type.lisp'
+        name: 'storage.type.function-type.lisp'
       '4':
-        'name': 'entity.name.function.lisp'
-    'match': '(\\b(?i:(defun|defmethod|defmacro))\\b)(\\s+)((\\w|\\-|\\!|\\?)*)'
-    'name': 'meta.function.lisp'
+        name: 'entity.name.function.lisp'
+    match: '(\\b(?i:(defun|defmethod|defmacro))\\b)(\\s+)((\\w|\\-|\\!|\\?)*)'
+    name: 'meta.function.lisp'
   }
   {
-    'captures':
+    captures:
       '1':
-        'name': 'punctuation.definition.constant.lisp'
-    'match': '(#)(\\w|[\\\\+-=<>\'"&#])+'
-    'name': 'constant.character.lisp'
+        name: 'punctuation.definition.constant.lisp'
+    match: '(#)(\\w|[\\\\+-=<>\'"&#])+'
+    name: 'constant.character.lisp'
   }
   {
-    'captures':
+    captures:
       '1':
-        'name': 'punctuation.definition.variable.lisp'
+        name: 'punctuation.definition.variable.lisp'
       '3':
-        'name': 'punctuation.definition.variable.lisp'
-    'match': '(\\*)(\\S*)(\\*)'
-    'name': 'variable.other.global.lisp'
+        name: 'punctuation.definition.variable.lisp'
+    match: '(\\*)(\\S*)(\\*)'
+    name: 'variable.other.global.lisp'
   }
   {
-    'match': '\\b(?i:case|do|let|loop|if|else|when)\\b'
-    'name': 'keyword.control.lisp'
+    match: '\\b(?i:case|do|let|loop|if|else|when)\\b'
+    name: 'keyword.control.lisp'
   }
   {
-    'match': '\\b(?i:eq|neq|and|or)\\b'
-    'name': 'keyword.operator.lisp'
+    match: '\\b(?i:eq|neq|and|or)\\b'
+    name: 'keyword.operator.lisp'
   }
   {
-    'match': '\\b(?i:null|nil)\\b'
-    'name': 'constant.language.lisp'
+    match: '\\b(?i:null|nil)\\b'
+    name: 'constant.language.lisp'
   }
   {
-    'match': '\\b(?i:cons|car|cdr|cond|lambda|format|setq|setf|quote|eval|append|list|listp|memberp|t|load|progn)\\b'
-    'name': 'support.function.lisp'
+    match: '\\b(?i:cons|car|cdr|cond|lambda|format|setq|setf|quote|eval|append|list|listp|memberp|t|load|progn)\\b'
+    name: 'support.function.lisp'
   }
   {
-    'match': '\\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\\b'
-    'name': 'constant.numeric.lisp'
+    match: '\\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)(L|l|UL|ul|u|U|F|f|ll|LL|ull|ULL)?\\b'
+    name: 'constant.numeric.lisp'
   }
   {
-    'begin': '"'
-    'beginCaptures':
+    begin: '"'
+    beginCaptures:
       '0':
-        'name': 'punctuation.definition.string.begin.lisp'
-    'end': '"'
-    'endCaptures':
+        name: 'punctuation.definition.string.begin.lisp'
+    end: '"'
+    endCaptures:
       '0':
-        'name': 'punctuation.definition.string.end.lisp'
-    'name': 'string.quoted.double.lisp'
-    'patterns': [
+        name: 'punctuation.definition.string.end.lisp'
+    name: 'string.quoted.double.lisp'
+    patterns: [
       {
-        'match': '\\\\.'
-        'name': 'constant.character.escape.lisp'
+        match: '\\\\.'
+        name: 'constant.character.escape.lisp'
       }
     ]
   }
 ]
-'scopeName': 'source.lisp'

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "language-lisp",
-  "version": "0.1.2",
-  "private": true,
-  "description": "Lisp support for Atom (converted from Textmate bundle)",
+  "version": "0.1.3",
+  "description": "Lisp support for Atom (originally converted from Textmate bundle)",
   "repository": "https://github.com/enriquefernandez/language-lisp",
   "license": "MIT",
   "engines": {
     "atom": ">0.50.0"
   },
-  "dependencies": {}
+  "dependencies": {
+  }
 }

--- a/settings/language-lisp.cson
+++ b/settings/language-lisp.cson
@@ -1,3 +1,4 @@
 '.source.lisp':
   'editor':
+    'commentStart': '; '
     'increaseIndentPattern': '^.*\\(.*[^)"]$'

--- a/settings/language-lisp.cson
+++ b/settings/language-lisp.cson
@@ -1,7 +1,7 @@
 '.source.lisp':
-  'editor':
-    'commentStart': '; '
-    'tabLength': 2
-    'increaseIndentPattern': '^.*\\(.*[^)"]$'
+  editor:
+    commentStart: '; '
+    tabLength: 2
+    increaseIndentPattern: '^.*\\(.*[^)"]$'
   "bracket-matcher":
     autocompleteBrackets: false

--- a/settings/language-lisp.cson
+++ b/settings/language-lisp.cson
@@ -3,3 +3,5 @@
     'commentStart': '; '
     'tabLength': 2
     'increaseIndentPattern': '^.*\\(.*[^)"]$'
+  "bracket-matcher":
+    autocompleteBrackets: false

--- a/settings/language-lisp.cson
+++ b/settings/language-lisp.cson
@@ -2,6 +2,6 @@
   editor:
     commentStart: '; '
     tabLength: 2
-  # TODO Following does not work!
+  # FIXME Following does not work!
   "bracket-matcher":
     autocompleteBrackets: false

--- a/settings/language-lisp.cson
+++ b/settings/language-lisp.cson
@@ -2,6 +2,8 @@
   editor:
     commentStart: '; '
     tabLength: 2
-    increaseIndentPattern: '^.*\\(.*[^)"]$'
+    # TODO nedělá, co by mělo
+    #increaseIndentPattern: '^.*\\(.*[^)"]$'
+  # TODO nefunguje
   "bracket-matcher":
     autocompleteBrackets: false

--- a/settings/language-lisp.cson
+++ b/settings/language-lisp.cson
@@ -1,4 +1,5 @@
 '.source.lisp':
   'editor':
     'commentStart': '; '
+    'tabLength': 2
     'increaseIndentPattern': '^.*\\(.*[^)"]$'

--- a/snippets/language-lisp.cson
+++ b/snippets/language-lisp.cson
@@ -38,3 +38,6 @@
   'setf':
     'prefix': 'setf'
     'body': '(setf ${1:place} ${2:value})'
+  'progn':
+    'prefix': 'progn'
+    'body': '(progn\n\t$0)'

--- a/snippets/language-lisp.cson
+++ b/snippets/language-lisp.cson
@@ -1,10 +1,10 @@
 '.source.lisp':
-  '\'(':
-    'prefix': '('
-    'body': '\'('
-  '`(':
-    'prefix': '('
-    'body': '\\`('
+  'quoted':
+    'prefix': 'quo'
+    'body': '\'($0)'
+  'backquoted':
+    'prefix': 'bq'
+    'body': '\`($0)'
   'defconstant':
     'prefix': 'const'
     'body': '(defconstant +${1:name}+ ${2:value}\n\t"${3:Documentation for $1.}"))'
@@ -20,13 +20,19 @@
   'defvar':
     'prefix': 'var'
     'body': '(defvar *${1:name}* ${2:value}\n\t"${3:Documentation for $1.}")'
+  'defclass':
+    'prefix': 'class'
+    'body': '(defclass ${1:name} (${2:superclass})\n\t"${3:Documentation for $1.}"\n\t($0))'
+  'defmethod':
+    'prefix': 'meth'
+    'body': '(defmethod ${1:name} ((self ${2:class}))\n\t"${3:Documentation for $1.}"\n\t($0))'
   'if':
     'prefix': 'if'
     'body': '(if (${1:test})\n\t($0))'
   'let':
     'prefix': 'let'
     'body': '(let (${1:variables})\n\t($0))'
-  'let1':
+  'let value':
     'prefix': 'let1'
     'body': '(let ((${1:variable} ${2:value}))\n\t($0))'
   'setf':

--- a/snippets/language-lisp.cson
+++ b/snippets/language-lisp.cson
@@ -1,43 +1,43 @@
 '.source.lisp':
-  'quoted':
-    'prefix': 'quo'
-    'body': '\'($0)'
-  'backquoted':
-    'prefix': 'bq'
-    'body': '\`($0)'
-  'defconstant':
-    'prefix': 'const'
-    'body': '(defconstant +${1:name}+ ${2:value}\n\t"${3:Documentation for $1.}"))'
-  'defmacro':
-    'prefix': 'mac'
-    'body': '(defmacro ${1:name} (${2:parameters})\n\t"${3:Documentation for $1.}"\n\t($0))'
-  'defparameter':
-    'prefix': 'par'
-    'body': '(defparameter *${1:name}* ${2:value}\n\t"${3:Documentation for $1.}")'
-  'defun':
-    'prefix': 'fun'
-    'body': '(defun ${1:name} (${2:parameters})\n\t"${3:Documentation for $1.}"\n\t($0))'
-  'defvar':
-    'prefix': 'var'
-    'body': '(defvar *${1:name}* ${2:value}\n\t"${3:Documentation for $1.}")'
-  'defclass':
-    'prefix': 'class'
-    'body': '(defclass ${1:name} (${2:superclass})\n\t"${3:Documentation for $1.}"\n\t($0))'
-  'defmethod':
-    'prefix': 'meth'
-    'body': '(defmethod ${1:name} ((self ${2:class}))\n\t"${3:Documentation for $1.}"\n\t($0))'
-  'if':
-    'prefix': 'if'
-    'body': '(if (${1:test})\n\t($0))'
-  'let':
-    'prefix': 'let'
-    'body': '(let (${1:variables})\n\t($0))'
-  'let value':
-    'prefix': 'let1'
-    'body': '(let ((${1:variable} ${2:value}))\n\t($0))'
-  'setf':
-    'prefix': 'setf'
-    'body': '(setf ${1:place} ${2:value})'
-  'progn':
-    'prefix': 'progn'
-    'body': '(progn\n\t$0)'
+  quoted:
+    prefix: 'quo'
+    body: '\'($0)'
+  backquoted:
+    prefix: 'bq'
+    body: '\`($0)'
+  defconstant:
+    prefix: 'const'
+    body: '(defconstant +${1:name}+ ${2:value}\n\t"${3:Documentation for $1.}"))'
+  defmacro:
+    prefix: 'mac'
+    body: '(defmacro ${1:name} (${2:parameters})\n\t"${3:Documentation for $1.}"\n\t($0))'
+  defparameter:
+    prefix: 'par'
+    body: '(defparameter *${1:name}* ${2:value}\n\t"${3:Documentation for $1.}")'
+  defun:
+    prefix: 'fun'
+    body: '(defun ${1:name} (${2:parameters})\n\t"${3:Documentation for $1.}"\n\t($0))'
+  defvar:
+    prefix: 'var'
+    body: '(defvar *${1:name}* ${2:value}\n\t"${3:Documentation for $1.}")'
+  defclass:
+    prefix: 'class'
+    body: '(defclass ${1:name} (${2:superclass})\n\t"${3:Documentation for $1.}"\n\t($0))'
+  defmethod:
+    prefix: 'meth'
+    body: '(defmethod ${1:name} ((self ${2:class}))\n\t"${3:Documentation for $1.}"\n\t($0))'
+  if:
+    prefix: 'if'
+    body: '(if (${1:test})\n\t($0))'
+  let:
+    prefix: 'let'
+    body: '(let (${1:variables})\n\t($0))'
+  "let value":
+    prefix: 'let1'
+    body: '(let ((${1:variable} ${2:value}))\n\t($0))'
+  setf:
+    prefix: 'setf'
+    body: '(setf ${1:place} ${2:value})'
+  progn:
+    prefix: 'progn'
+    body: '(progn\n\t$0)'


### PR DESCRIPTION
I just spent _few days_ modifying this language package – major highlights are:
- added **multi-line comment** support
- added some often-used **functions**
- added support for `:keywords` and `&keys`
- refreshed old **snippets**, added some new ones
- added more description text to **readme**
- removed those awful quotes around everything – these are not needed in CSON
- added **folding** support
- removed indentation regex, which can never work correctly due to nature of Lisp; this should be solved by external plugin like Paredit or Parinfer, also I plan doing simple tabkey-indenter
- there is one _FIXME_ in settings file, because bracket matcher should be configurable for not putting double single-quotes for languages which don't use them, f.e. Lisp.

If you like my edits I would be glad if you publish them. Please note that I sometimes just reorganized lines, even though it counts as edit.
