### PR TITLE
Adding emacs and spacemacs file extensions

### DIFF
--- a/grammars/lisp.cson
+++ b/grammars/lisp.cson
@@ -7,6 +7,8 @@ fileTypes: [
   'l'
   'mud'
   'el'
+  'emacs'
+  'spacemacs'
 ]
 foldingStartMarker: '\\(\\s*$'
 foldingStopMarker: '^\\s*\\)'


### PR DESCRIPTION
In this pull I am adding `.emacs` and `.spacemacs` files to the list of auto-highlighted file types. 
